### PR TITLE
Fix quoting for Windows server start

### DIFF
--- a/php/server.php
+++ b/php/server.php
@@ -173,10 +173,12 @@ function startServer() {
         
         // Executar o arquivo .bat em background
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-            $command = 'start /B "" "' . $serverPath . '"';
+            // Escapar e incluir título vazio para suportar caminhos com espaços
+            $escapedPath = escapeshellarg($serverPath);
+            $command = 'start "" /B ' . $escapedPath;
             pclose(popen($command, 'r'));
         } else {
-            $command = 'nohup "' . $serverPath . '" > /dev/null 2>&1 &';
+            $command = 'nohup ' . escapeshellarg($serverPath) . ' > /dev/null 2>&1 &';
             shell_exec($command);
         }
         


### PR DESCRIPTION
## Summary
- fix start command quoting to support spaces in Windows paths

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6851aeedadc483328a5667ecdfb65cd8